### PR TITLE
 Post rules handling in jobCatcher, bullock handling queues and jobs depends on config

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -50,7 +50,9 @@ module.exports = {
   // Configuration of the application server
   app: {
     // Local port on which to run the app server
-    port: +process.env.BEAM_DEV_APP_PORT || 3000
+    port: +process.env.BEAM_DEV_APP_PORT || 3000,
+    // Comma separated list of the queue that the worker handles
+    queues: process.env.BEAM_PROD_APP_QUEUES || 'media_workers',
   },
   // Rules that match path patterns and cause work to happen
   // - All rules can be overridden by a config files loaded on the command line

--- a/config/production.js
+++ b/config/production.js
@@ -50,7 +50,9 @@ module.exports = {
   // Configuration of the application server
   app: {
     // Local port on which to run the app server
-    port: +process.env.BEAM_PROD_APP_PORT || 3000
+    port: +process.env.BEAM_DEV_APP_PORT || 3000,
+    // Comma separated list of the queue that the worker handles
+    queues: process.env.BEAM_PROD_APP_QUEUES || 'media_workers',
   },
   // Rules that match path patterns and cause work to happen
   // - All rules can be overridden by a config files loaded on the command line

--- a/config/test.js
+++ b/config/test.js
@@ -50,7 +50,9 @@ module.exports = {
   // Configuration of the application server
   app: {
     // Local port on which to run the app server
-    port: +process.env.BEAM_TEST_APP_PORT || 13131
+    port: +process.env.BEAM_TEST_APP_PORT || 13131,
+    // Comma separated list of the queue that the worker handles
+    queues: process.env.BEAM_PROD_APP_QUEUES || 'media_workers',
   },
   // Rules that match path patterns and cause work to happen
   // - All rules can be overridden by a config files loaded on the command line

--- a/lib/jobCatcher.js
+++ b/lib/jobCatcher.js
@@ -37,6 +37,9 @@ Object.keys(config.rules).forEach(k => {
   if (rule.statusCode && !Array.isArray(rule.statusCode)) {
     rule.statusCode = [ rule.statusCode ];
   }
+  if (rule.method && !Array.isArray(rule.method)) {
+    rule.method = [ rule.method ];
+  }
   if (!queues[rule.queue]) {
     queues[rule.queue] = new Queue(rule.queue, { redis: {
       port: config.redis.port, host: config.redis.host }});
@@ -50,6 +53,9 @@ async function jobCatcher (ctx, next) {
 
   for ( let x = 0 ; x < preRules.length ; x++ ) {
     let rule = preRules[x];
+    if (rule.method.indexOf(ctx.request.method) < 0) {
+      continue;
+    }
     let match = rule.pathRE.exec(ctx.path);
     if (match) {
       let bullock = await queues[rule.queue].add({
@@ -80,15 +86,30 @@ async function jobCatcher (ctx, next) {
       }
     }
   }
-  await next();
 
-  /* postJobs.forEach(x => {
-    if (x.statusCode.indexOf(ctx.status) < 0) return;
-    let match = x.pathRE.exec(ctx.path);
-    if (match) {
-      // add post process job to bull
+  try {
+    await next();
+  } finally {
+    for ( let x = 0 ; x < postRules.length ; x++ ) {
+      const rule = postRules[x];
+      if (rule.statusCode.indexOf(ctx.status) < 0 || rule.method.indexOf(ctx.request.method) < 0) {
+        continue;
+      }
+      const match = rule.pathRE.exec(ctx.path);
+      if (match && queues[rule.queue]) {
+        const bullock = await queues[rule.queue].add({
+          rule: rule,
+          path: ctx.path,
+          headers: ctx.request.headers,
+          method: ctx.request.method,
+          body: (ctx.request.type === 'application/json') ? ctx.request.body : null,
+        });
+
+        const result = await bullock.finished();
+        //console.log(result);
+      }
     }
-  }); */
+  }
 }
 
 async function closeQueues() {

--- a/lib/workers/bullock.js
+++ b/lib/workers/bullock.js
@@ -20,20 +20,29 @@
   14 Ormiscaig, Aultbea, Achnasheen, IV22 2JJ  U.K.
 */
 
+const config = require('../../config.js');
 const { redisio, queue } = require('../../index.js');
-const consumer = queue('media_workers');
 
-const mediaWorkers = {
-  makeJPEG: require('./makeJPEG.js'),
-  makeMP4: require('./makeMP4.js')
-};
+const queues = config.app.queues.split(',');
+const consumers = queues.map( x => queue(x) );
+const workers = {};
 
-consumer.process(async job => {
-  const worker = mediaWorkers[job.data.rule.function];
-  if (worker)
-    return await worker(job);
-  else
-    throw new Error('media worker job failed!');
+Object.keys(config.rules).forEach(k => {
+  const rule = config.rules[k];
+  if (rule.queue && queues.includes(rule.queue) && rule.function) {
+    workers[rule.function] = require(`./${rule.function}.js`);
+  }
+});
+
+consumers.forEach(consumer => {
+  consumer.process(async job => {
+    const worker = workers[job.data.rule.function];
+    if (worker) {
+      return await worker(job);
+    } else {
+      throw new Error('file worker job failed!');
+    }
+  });
 });
 
 process.on('SIGINT', async () => {


### PR DESCRIPTION
Here are the summary of changes:

1. Post rules handling implementation based on docs.
2. Reading queues and handling jobs are depends on config instead of hardcode in `bullock.js`.